### PR TITLE
Use POSIX compliant shebang

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Description:
 # Podspec auto patching script for React Native projects.
 # It download, patches the podspec and updating Podfile


### PR DESCRIPTION
`/bin/bash` will be missing on a few OS's such as NixOS, GoboLinux, Guix, and a few others